### PR TITLE
Diagnostic Policy API Updates

### DIFF
--- a/ARM/Policy/DiagnosticSettings/LogAnalytics/arm-ttk-tests.ps1
+++ b/ARM/Policy/DiagnosticSettings/LogAnalytics/arm-ttk-tests.ps1
@@ -1,4 +1,1 @@
-﻿Test-AzTemplate $PSScriptRoot -Pester -Skip "apiVersions Should Be Recent"
-
-# Disable ARM TTK due to a JSON parsing issue with nested templates.
-# Disable apiVersions Should Be Recent - Due to a bug in ARM TTK for Diagnostic Settings
+﻿Test-AzTemplate $PSScriptRoot -Pester

--- a/ARM/Policy/DiagnosticSettings/LogAnalytics/azuredeploy.json
+++ b/ARM/Policy/DiagnosticSettings/LogAnalytics/azuredeploy.json
@@ -86,7 +86,7 @@
     {
       "name": "[parameters('policies')[copyIndex()]]",
       "type": "Microsoft.Resources/deployments",
-      "apiVersion": "2019-08-01",
+      "apiVersion": "2021-04-01",
       "location": "[parameters('location')]",
       "properties": {
         "mode": "Incremental",

--- a/ARM/Policy/DiagnosticSettings/LogAnalytics/diagnostics-aa-deploy-policy.json
+++ b/ARM/Policy/DiagnosticSettings/LogAnalytics/diagnostics-aa-deploy-policy.json
@@ -5,7 +5,7 @@
     {
       "type": "Microsoft.Authorization/policyDefinitions",
       "name": "diagnostics-aa-deploy-policy",
-      "apiVersion": "2019-09-01",
+      "apiVersion": "2021-06-01",
       "properties": {
         "displayName": "Deploy Diagnostics & Metrics for Automation Accounts to a Log Analytics workspace",
         "description": "Apply diagnostic & metric settings for Automation Accounts to stream data to a Log Analytics workspace when any Automation Account which is missing this diagnostic settings is created or updated.",

--- a/ARM/Policy/DiagnosticSettings/LogAnalytics/diagnostics-adf-deploy-policy.json
+++ b/ARM/Policy/DiagnosticSettings/LogAnalytics/diagnostics-adf-deploy-policy.json
@@ -5,7 +5,7 @@
     {
       "type": "Microsoft.Authorization/policyDefinitions",
       "name": "diagnostics-adf-deploy-policy",
-      "apiVersion": "2019-09-01",
+      "apiVersion": "2021-06-01",
       "properties": {
         "displayName": "Deploy Diagnostics & Metrics for Data Factory to a Log Analytics workspace",
         "description": "Apply diagnostic & metric settings for Data Factory to stream data to a Log Analytics workspace when any Data Factory which is missing this diagnostic settings is created or updated.",

--- a/ARM/Policy/DiagnosticSettings/LogAnalytics/diagnostics-agw-deploy-policy.json
+++ b/ARM/Policy/DiagnosticSettings/LogAnalytics/diagnostics-agw-deploy-policy.json
@@ -5,7 +5,7 @@
     {
       "type": "Microsoft.Authorization/policyDefinitions",
       "name": "diagnostics-agw-deploy-policy",
-      "apiVersion": "2019-09-01",
+      "apiVersion": "2021-06-01",
       "properties": {
         "displayName": "Deploy Diagnostics & Metrics for Application Gateway to a Log Analytics workspace",
         "description": "Apply diagnostic & metric settings for Application Gateway to stream data to a Log Analytics workspace when any Application Gateway which is missing this diagnostic settings is created or updated.",

--- a/ARM/Policy/DiagnosticSettings/LogAnalytics/diagnostics-aks-deploy-policy.json
+++ b/ARM/Policy/DiagnosticSettings/LogAnalytics/diagnostics-aks-deploy-policy.json
@@ -5,7 +5,7 @@
     {
       "type": "Microsoft.Authorization/policyDefinitions",
       "name": "diagnostics-aks-deploy-policy",
-      "apiVersion": "2019-09-01",
+      "apiVersion": "2021-06-01",
       "properties": {
         "displayName": "Deploy Diagnostics & Metrics for Kubernetes Service to a Log Analytics workspace",
         "description": "Apply diagnostic & metric settings for Kubernetes Service to stream data to a Log Analytics workspace when any Kubernetes Serice which is missing this diagnostic settings is created or updated.",

--- a/ARM/Policy/DiagnosticSettings/LogAnalytics/diagnostics-apim-deploy-policy.json
+++ b/ARM/Policy/DiagnosticSettings/LogAnalytics/diagnostics-apim-deploy-policy.json
@@ -5,7 +5,7 @@
     {
       "type": "Microsoft.Authorization/policyDefinitions",
       "name": "diagnostics-apim-deploy-policy",
-      "apiVersion": "2019-09-01",
+      "apiVersion": "2021-06-01",
       "properties": {
         "displayName": "Deploy Diagnostics & Metrics for API Management to a Log Analytics workspace",
         "description": "Apply diagnostic & metric settings for API Management to stream data to a Log Analytics workspace when any API Management which is missing this diagnostic settings is created or updated.",

--- a/ARM/Policy/DiagnosticSettings/LogAnalytics/diagnostics-app-deploy-policy.json
+++ b/ARM/Policy/DiagnosticSettings/LogAnalytics/diagnostics-app-deploy-policy.json
@@ -5,7 +5,7 @@
     {
       "type": "Microsoft.Authorization/policyDefinitions",
       "name": "diagnostics-app-deploy-policy",
-      "apiVersion": "2019-09-01",
+      "apiVersion": "2021-06-01",
       "properties": {
         "displayName": "Deploy Diagnostics & Metrics for App Service to a Log Analytics workspace",
         "description": "Apply diagnostic & metric settings for App Service to stream data to a Log Analytics workspace when any App Service which is missing this diagnostic settings is created or updated.",

--- a/ARM/Policy/DiagnosticSettings/LogAnalytics/diagnostics-as-deploy-policy.json
+++ b/ARM/Policy/DiagnosticSettings/LogAnalytics/diagnostics-as-deploy-policy.json
@@ -5,7 +5,7 @@
     {
       "type": "Microsoft.Authorization/policyDefinitions",
       "name": "diagnostics-as-deploy-policy",
-      "apiVersion": "2019-09-01",
+      "apiVersion": "2021-06-01",
       "properties": {
         "displayName": "Deploy Diagnostics & Metrics for Analysis Services to a Log Analytics workspace",
         "description": "Apply diagnostic settings for Analysis Services to send data to a Log Analytics workspace which is missing this diagnostic settings is created or updated.",

--- a/ARM/Policy/DiagnosticSettings/LogAnalytics/diagnostics-asa-deploy-policy.json
+++ b/ARM/Policy/DiagnosticSettings/LogAnalytics/diagnostics-asa-deploy-policy.json
@@ -5,7 +5,7 @@
     {
       "type": "Microsoft.Authorization/policyDefinitions",
       "name": "diagnostics-asa-deploy-policy",
-      "apiVersion": "2019-09-01",
+      "apiVersion": "2021-06-01",
       "properties": {
         "displayName": "Deploy Diagnostics & Metrics for Stream Analytic to a Log Analytics workspace",
         "description": "Apply diagnostic & metric settings for Stream Analytic to stream data to a Log Analytics workspace when any Stream Analytic which is missing this diagnostic settings is created or updated.",

--- a/ARM/Policy/DiagnosticSettings/LogAnalytics/diagnostics-batch-deploy-policy.json
+++ b/ARM/Policy/DiagnosticSettings/LogAnalytics/diagnostics-batch-deploy-policy.json
@@ -5,7 +5,7 @@
     {
       "type": "Microsoft.Authorization/policyDefinitions",
       "name": "diagnostics-batch-deploy-policy",
-      "apiVersion": "2019-09-01",
+      "apiVersion": "2021-06-01",
       "properties": {
         "displayName": "Deploy Diagnostics & Metrics for Batch Accounts to a Log Analytics workspace",
         "description": "Apply diagnostic & metric settings for Batch Account to stream to a Log Analytics workspace when any Batch Account which is missing this diagnostic settings is created or updated.",

--- a/ARM/Policy/DiagnosticSettings/LogAnalytics/diagnostics-cdne-deploy-policy.json
+++ b/ARM/Policy/DiagnosticSettings/LogAnalytics/diagnostics-cdne-deploy-policy.json
@@ -5,7 +5,7 @@
     {
       "type": "Microsoft.Authorization/policyDefinitions",
       "name": "diagnostics-cdne-deploy-policy",
-      "apiVersion": "2019-09-01",
+      "apiVersion": "2021-06-01",
       "properties": {
         "displayName": "Deploy Diagnostics & Metrics for Content Delivery Network Endpoint to a Log Analytics workspace",
         "description": "Apply diagnostic & metric settings for Content Delivery Network Endpoint to stream data to a Log Analytics workspace when any Content Delivery Network Endpoint which is missing this diagnostic settings is created or updated.",

--- a/ARM/Policy/DiagnosticSettings/LogAnalytics/diagnostics-ci-deploy-policy.json
+++ b/ARM/Policy/DiagnosticSettings/LogAnalytics/diagnostics-ci-deploy-policy.json
@@ -5,7 +5,7 @@
     {
       "type": "Microsoft.Authorization/policyDefinitions",
       "name": "diagnostics-ci-deploy-policy",
-      "apiVersion": "2019-09-01",
+      "apiVersion": "2021-06-01",
       "properties": {
         "displayName": "Deploy Diagnostics & Metrics for Container Instance to a Log Analytics workspace",
         "description": "Apply diagnostic & metric settings for Container Instance to stream data to a Log Analytics workspace when any Container Instance which is missing this diagnostic settings is created or updated.",

--- a/ARM/Policy/DiagnosticSettings/LogAnalytics/diagnostics-cog-deploy-policy.json
+++ b/ARM/Policy/DiagnosticSettings/LogAnalytics/diagnostics-cog-deploy-policy.json
@@ -5,7 +5,7 @@
     {
       "type": "Microsoft.Authorization/policyDefinitions",
       "name": "diagnostics-cog-deploy-policy",
-      "apiVersion": "2019-09-01",
+      "apiVersion": "2021-06-01",
       "properties": {
         "displayName": "Deploy Diagnostics & Metrics for Cognitive Services to a Log Analytics workspace",
         "description": "Apply diagnostic & metric settings for Cognitive Services to stream data to a Log Analytics workspace when any Cognitive Services which is missing this diagnostic settings is created or updated.",

--- a/ARM/Policy/DiagnosticSettings/LogAnalytics/diagnostics-cosmos-deploy-policy.json
+++ b/ARM/Policy/DiagnosticSettings/LogAnalytics/diagnostics-cosmos-deploy-policy.json
@@ -5,7 +5,7 @@
     {
       "type": "Microsoft.Authorization/policyDefinitions",
       "name": "diagnostics-cosmos-deploy-policy",
-      "apiVersion": "2019-09-01",
+      "apiVersion": "2021-06-01",
       "properties": {
         "displayName": "Deploy Diagnostics & Metrics for CosmosDB to a Log Analytics workspace",
         "description": "Apply diagnostic & metric settings for CosmosDB to stream data to a Log Analytics workspace when any CosmosDB which is missing this diagnostic settings is created or updated.",

--- a/ARM/Policy/DiagnosticSettings/LogAnalytics/diagnostics-cr-deploy-policy.json
+++ b/ARM/Policy/DiagnosticSettings/LogAnalytics/diagnostics-cr-deploy-policy.json
@@ -5,7 +5,7 @@
     {
       "type": "Microsoft.Authorization/policyDefinitions",
       "name": "diagnostics-cr-deploy-policy",
-      "apiVersion": "2019-09-01",
+      "apiVersion": "2021-06-01",
       "properties": {
         "displayName": "Deploy Diagnostics & Metrics for Container Registry to a Log Analytics workspace",
         "description": "Apply diagnostic & metric settings for Container Registry to stream data to a Log Analytics workspace when any Container Registry which is missing this diagnostic settings is created or updated.",

--- a/ARM/Policy/DiagnosticSettings/LogAnalytics/diagnostics-dla-deploy-policy.json
+++ b/ARM/Policy/DiagnosticSettings/LogAnalytics/diagnostics-dla-deploy-policy.json
@@ -5,7 +5,7 @@
     {
       "type": "Microsoft.Authorization/policyDefinitions",
       "name": "diagnostics-dla-deploy-policy",
-      "apiVersion": "2019-09-01",
+      "apiVersion": "2021-06-01",
       "properties": {
         "displayName": "Deploy Diagnostics & Metrics for Data Lake Analytics to a Log Analytics workspace",
         "description": "Apply diagnostic & metric settings for Data Lake Analytics to stream data to a Log Analytics workspace when any Data Lake Analytics which is missing this diagnostic settings is created or updated.",

--- a/ARM/Policy/DiagnosticSettings/LogAnalytics/diagnostics-dls-deploy-policy.json
+++ b/ARM/Policy/DiagnosticSettings/LogAnalytics/diagnostics-dls-deploy-policy.json
@@ -5,7 +5,7 @@
     {
       "type": "Microsoft.Authorization/policyDefinitions",
       "name": "diagnostics-dls-deploy-policy",
-      "apiVersion": "2019-09-01",
+      "apiVersion": "2021-06-01",
       "properties": {
         "displayName": "Deploy Diagnostics & Metrics for Data Lake Store to a Log Analytics workspace",
         "description": "Apply diagnostic & metric settings for Data Lake Store to stream data to a Log Analytics workspace when any Data Lake Store which is missing this diagnostic settings is created or updated.",

--- a/ARM/Policy/DiagnosticSettings/LogAnalytics/diagnostics-erc-deploy-policy.json
+++ b/ARM/Policy/DiagnosticSettings/LogAnalytics/diagnostics-erc-deploy-policy.json
@@ -5,7 +5,7 @@
     {
       "type": "Microsoft.Authorization/policyDefinitions",
       "name": "diagnostics-erc-deploy-policy",
-      "apiVersion": "2019-09-01",
+      "apiVersion": "2021-06-01",
       "properties": {
         "displayName": "Deploy Diagnostics & Metrics for Express Route to a Log Analytics workspace",
         "description": "Apply diagnostic & metric settings for Express Route to stream data to a Log Analytics workspace when any Express Route which is missing this diagnostic settings is created or updated.",

--- a/ARM/Policy/DiagnosticSettings/LogAnalytics/diagnostics-esub-deploy-policy.json
+++ b/ARM/Policy/DiagnosticSettings/LogAnalytics/diagnostics-esub-deploy-policy.json
@@ -5,7 +5,7 @@
     {
       "type": "Microsoft.Authorization/policyDefinitions",
       "name": "diagnostics-esub-deploy-policy",
-      "apiVersion": "2019-09-01",
+      "apiVersion": "2021-06-01",
       "properties": {
         "displayName": "Deploy Diagnostics & Metrics for Event Grid Subscription to a Log Analytics workspace",
         "description": "Apply diagnostic & metric settings for Event Grid Subscription to stream data to a Log Analytics workspace when any Event Grid Subscription which is missing this diagnostic settings is created or updated.",

--- a/ARM/Policy/DiagnosticSettings/LogAnalytics/diagnostics-evgt-deploy-policy.json
+++ b/ARM/Policy/DiagnosticSettings/LogAnalytics/diagnostics-evgt-deploy-policy.json
@@ -5,7 +5,7 @@
     {
       "type": "Microsoft.Authorization/policyDefinitions",
       "name": "diagnostics-evgt-deploy-policy",
-      "apiVersion": "2019-09-01",
+      "apiVersion": "2021-06-01",
       "properties": {
         "displayName": "Deploy Diagnostics & Metrics for Event Grid Topic to a Log Analytics workspace",
         "description": "Apply diagnostic & metric settings for Event Grid Topic to stream data to a Log Analytics workspace when any Kubernetes Serice which is missing this diagnostic settings is created or updated.",

--- a/ARM/Policy/DiagnosticSettings/LogAnalytics/diagnostics-evhns-deploy-policy.json
+++ b/ARM/Policy/DiagnosticSettings/LogAnalytics/diagnostics-evhns-deploy-policy.json
@@ -5,7 +5,7 @@
     {
       "type": "Microsoft.Authorization/policyDefinitions",
       "name": "diagnostics-evhns-deploy-policy",
-      "apiVersion": "2019-09-01",
+      "apiVersion": "2021-06-01",
       "properties": {
         "displayName": "Deploy Diagnostics & Metrics for Event Hub to a Log Analytics workspace",
         "description": "Apply diagnostic & metric settings for Event Hub to stream data to a Log Analytics workspace when any Event Hub which is missing this diagnostic settings is created or updated.",

--- a/ARM/Policy/DiagnosticSettings/LogAnalytics/diagnostics-fd-deploy-policy.json
+++ b/ARM/Policy/DiagnosticSettings/LogAnalytics/diagnostics-fd-deploy-policy.json
@@ -5,7 +5,7 @@
     {
       "type": "Microsoft.Authorization/policyDefinitions",
       "name": "diagnostics-fd-deploy-policy",
-      "apiVersion": "2019-09-01",
+      "apiVersion": "2021-06-01",
       "properties": {
         "displayName": "Deploy Diagnostics & Metrics for Front Door to a Log Analytics workspace",
         "description": "Apply diagnostic & metric settings for Front Door to stream data to a Log Analytics workspacewhen any Front Door which is missing this diagnostic settings is created or updated.",

--- a/ARM/Policy/DiagnosticSettings/LogAnalytics/diagnostics-func-deploy-policy.json
+++ b/ARM/Policy/DiagnosticSettings/LogAnalytics/diagnostics-func-deploy-policy.json
@@ -5,7 +5,7 @@
     {
       "type": "Microsoft.Authorization/policyDefinitions",
       "name": "diagnostics-func-deploy-policy",
-      "apiVersion": "2019-09-01",
+      "apiVersion": "2021-06-01",
       "properties": {
         "displayName": "Deploy Diagnostics & Metrics for Function App to a Log Analytics workspace",
         "description": "Apply diagnostic & metric settings for Function App to stream data to a Log Analytics workspace when any Function App which is missing this diagnostic settings is created or updated.",

--- a/ARM/Policy/DiagnosticSettings/LogAnalytics/diagnostics-fw-deploy-policy.json
+++ b/ARM/Policy/DiagnosticSettings/LogAnalytics/diagnostics-fw-deploy-policy.json
@@ -5,7 +5,7 @@
     {
       "type": "Microsoft.Authorization/policyDefinitions",
       "name": "diagnostics-fw-deploy-policy",
-      "apiVersion": "2019-09-01",
+      "apiVersion": "2021-06-01",
       "properties": {
         "displayName": "Deploy Diagnostics & Metrics for Firewall to a Log Analytics workspace",
         "description": "Apply diagnostic & metric settings for Firewall to stream data to a Log Analytics workspace when any Firewall which is missing this diagnostic settings is created or updated.",

--- a/ARM/Policy/DiagnosticSettings/LogAnalytics/diagnostics-hdinsight-deploy-policy.json
+++ b/ARM/Policy/DiagnosticSettings/LogAnalytics/diagnostics-hdinsight-deploy-policy.json
@@ -5,7 +5,7 @@
     {
       "type": "Microsoft.Authorization/policyDefinitions",
       "name": "diagnostics-hdinsight-deploy-policy",
-      "apiVersion": "2019-09-01",
+      "apiVersion": "2021-06-01",
       "properties": {
         "displayName": "Deploy Diagnostics & Metrics for HDInsight to a Log Analytics workspace",
         "description": "Apply diagnostic & metric settings for HDInsight to stream data to a Log Analytics workspace when any HDInsight which is missing this diagnostic settings is created or updated.",

--- a/ARM/Policy/DiagnosticSettings/LogAnalytics/diagnostics-ia-deploy-policy.json
+++ b/ARM/Policy/DiagnosticSettings/LogAnalytics/diagnostics-ia-deploy-policy.json
@@ -5,7 +5,7 @@
     {
       "type": "Microsoft.Authorization/policyDefinitions",
       "name": "diagnostics-ia-deploy-policy",
-      "apiVersion": "2019-09-01",
+      "apiVersion": "2021-06-01",
       "properties": {
         "displayName": "Deploy Diagnostics & Metrics for Logic App Integration Account to a Log Analytics workspace",
         "description": "Apply diagnostic & metric settings for Logic App Integration Account to stream data to a Log Analytics workspace when any Logic App Integration Account which is missing this diagnostic settings is created or updated.",

--- a/ARM/Policy/DiagnosticSettings/LogAnalytics/diagnostics-iot-deploy-policy.json
+++ b/ARM/Policy/DiagnosticSettings/LogAnalytics/diagnostics-iot-deploy-policy.json
@@ -5,7 +5,7 @@
     {
       "type": "Microsoft.Authorization/policyDefinitions",
       "name": "diagnostics-iot-deploy-policy",
-      "apiVersion": "2019-09-01",
+      "apiVersion": "2021-06-01",
       "properties": {
         "displayName": "Deploy Diagnostics & Metrics for IoT Hubs  to a Log Analytics workspace",
         "description": "Apply diagnostic & metric settings for IoT Hubs  to stream data to a Log Analytics workspace when any IoT Hubs  which is missing this diagnostic settings is created or updated.",

--- a/ARM/Policy/DiagnosticSettings/LogAnalytics/diagnostics-kv-deploy-policy.json
+++ b/ARM/Policy/DiagnosticSettings/LogAnalytics/diagnostics-kv-deploy-policy.json
@@ -5,7 +5,7 @@
     {
       "type": "Microsoft.Authorization/policyDefinitions",
       "name": "diagnostics-kv-deploy-policy",
-      "apiVersion": "2019-09-01",
+      "apiVersion": "2021-06-01",
       "properties": {
         "displayName": "Deploy Diagnostics & Metrics for Key Vault to a Log Analytics workspace",
         "description": "Apply diagnostic & metric settings for Key Vault to stream data to a Log Analytics workspace when any Key Vault which is missing this diagnostic settings is created or updated.",

--- a/ARM/Policy/DiagnosticSettings/LogAnalytics/diagnostics-lb-deploy-policy.json
+++ b/ARM/Policy/DiagnosticSettings/LogAnalytics/diagnostics-lb-deploy-policy.json
@@ -5,7 +5,7 @@
     {
       "type": "Microsoft.Authorization/policyDefinitions",
       "name": "diagnostics-lb-deploy-policy",
-      "apiVersion": "2019-09-01",
+      "apiVersion": "2021-06-01",
       "properties": {
         "displayName": "Deploy Diagnostics & Metrics for Load Balancers to a Log Analytics workspace",
         "description": "Apply diagnostic & metric settings for Load Balancers to stream data to a Log Analytics workspace when any Load Balancers which is missing this diagnostic settings is created or updated.",

--- a/ARM/Policy/DiagnosticSettings/LogAnalytics/diagnostics-log-deploy-policy.json
+++ b/ARM/Policy/DiagnosticSettings/LogAnalytics/diagnostics-log-deploy-policy.json
@@ -5,7 +5,7 @@
     {
       "type": "Microsoft.Authorization/policyDefinitions",
       "name": "diagnostics-log-deploy-policy",
-      "apiVersion": "2019-09-01",
+      "apiVersion": "2021-06-01",
       "properties": {
         "displayName": "Deploy Diagnostics & Metrics for Log Analytics to a Log Analytics workspace",
         "description": "Apply diagnostic & metric settings for Log Analytics to stream data to a Log Analytics workspace when any Log Analytics which is missing this diagnostic settings is created or updated.",

--- a/ARM/Policy/DiagnosticSettings/LogAnalytics/diagnostics-logic-deploy-policy.json
+++ b/ARM/Policy/DiagnosticSettings/LogAnalytics/diagnostics-logic-deploy-policy.json
@@ -5,7 +5,7 @@
     {
       "type": "Microsoft.Authorization/policyDefinitions",
       "name": "diagnostics-logic-deploy-policy",
-      "apiVersion": "2019-09-01",
+      "apiVersion": "2021-06-01",
       "properties": {
         "displayName": "Deploy Diagnostics & Metrics for Logic App Workflow to a Log Analytics workspace",
         "description": "Apply diagnostic & metric settings for Logic App Workflow to stream data to a Log Analytics workspace when any Logic App Workflow which is missing this diagnostic settings is created or updated.",

--- a/ARM/Policy/DiagnosticSettings/LogAnalytics/diagnostics-mysql-deploy-policy.json
+++ b/ARM/Policy/DiagnosticSettings/LogAnalytics/diagnostics-mysql-deploy-policy.json
@@ -5,7 +5,7 @@
     {
       "type": "Microsoft.Authorization/policyDefinitions",
       "name": "diagnostics-mysql-deploy-policy",
-      "apiVersion": "2019-09-01",
+      "apiVersion": "2021-06-01",
       "properties": {
         "displayName": "Deploy Diagnostics & Metrics for MySQL Database to a Log Analytics workspace",
         "description": "Apply diagnostic & metric settings for MySQL Database to stream data to a Log Analytics workspace when any MySQL Database which is missing this diagnostic settings is created or updated.",

--- a/ARM/Policy/DiagnosticSettings/LogAnalytics/diagnostics-net-deploy-policy.json
+++ b/ARM/Policy/DiagnosticSettings/LogAnalytics/diagnostics-net-deploy-policy.json
@@ -5,7 +5,7 @@
     {
       "type": "Microsoft.Authorization/policyDefinitions",
       "name": "diagnostics-net-deploy-policy",
-      "apiVersion": "2019-09-01",
+      "apiVersion": "2021-06-01",
       "properties": {
         "displayName": "Deploy Diagnostics & Metrics for Virtual Networks to a Log Analytics workspace",
         "description": "Apply diagnostic & metric settings for Virtual Networks to stream data to a Log Analytics workspace when any Virtual Networks which is missing this diagnostic settings is created or updated.",

--- a/ARM/Policy/DiagnosticSettings/LogAnalytics/diagnostics-nic-deploy-policy.json
+++ b/ARM/Policy/DiagnosticSettings/LogAnalytics/diagnostics-nic-deploy-policy.json
@@ -5,7 +5,7 @@
     {
       "type": "Microsoft.Authorization/policyDefinitions",
       "name": "diagnostics-nic-deploy-policy",
-      "apiVersion": "2019-09-01",
+      "apiVersion": "2021-06-01",
       "properties": {
         "displayName": "Deploy Diagnostics & Metrics for Network Interface to a Log Analytics workspace",
         "description": "Apply diagnostic & metric settings for Network Interface to stream data to a Log Analytics workspace when any Network Interface which is missing this diagnostic settings is created or updated.",

--- a/ARM/Policy/DiagnosticSettings/LogAnalytics/diagnostics-nsg-deploy-policy.json
+++ b/ARM/Policy/DiagnosticSettings/LogAnalytics/diagnostics-nsg-deploy-policy.json
@@ -5,7 +5,7 @@
     {
       "type": "Microsoft.Authorization/policyDefinitions",
       "name": "diagnostics-nsg-deploy-policy",
-      "apiVersion": "2019-09-01",
+      "apiVersion": "2021-06-01",
       "properties": {
         "displayName": "Deploy Diagnostics & Metrics for Network Security Group to a Log Analytics workspace",
         "description": "Apply diagnostic & metric settings for Network Security Group to stream data to a Log Analytics workspace when any Network Security Group which is missing this diagnostic settings is created or updated.",

--- a/ARM/Policy/DiagnosticSettings/LogAnalytics/diagnostics-pbi-deploy-policy.json
+++ b/ARM/Policy/DiagnosticSettings/LogAnalytics/diagnostics-pbi-deploy-policy.json
@@ -5,7 +5,7 @@
     {
       "type": "Microsoft.Authorization/policyDefinitions",
       "name": "diagnostics-pbi-deploy-policy",
-      "apiVersion": "2019-09-01",
+      "apiVersion": "2021-06-01",
       "properties": {
         "displayName": "Deploy Diagnostics & Metrics for Power BI Embedded to a Log Analytics workspace",
         "description": "Apply diagnostic & metric settings for Power BI Embedded to stream data to a Log Analytics workspace when any Power BI Embedded which is missing this diagnostic settings is created or updated.",

--- a/ARM/Policy/DiagnosticSettings/LogAnalytics/diagnostics-pip-deploy-policy.json
+++ b/ARM/Policy/DiagnosticSettings/LogAnalytics/diagnostics-pip-deploy-policy.json
@@ -5,7 +5,7 @@
     {
       "type": "Microsoft.Authorization/policyDefinitions",
       "name": "diagnostics-pip-deploy-policy",
-      "apiVersion": "2019-09-01",
+      "apiVersion": "2021-06-01",
       "properties": {
         "displayName": "Deploy Diagnostics & Metrics for Public IP Addresse to a Log Analytics workspace",
         "description": "Apply diagnostic & metric settings for Public IP Addresse to stream data to a Log Analytics workspace when any Public IP Addresse which is missing this diagnostic settings is created or updated.",

--- a/ARM/Policy/DiagnosticSettings/LogAnalytics/diagnostics-plan-deploy-policy.json
+++ b/ARM/Policy/DiagnosticSettings/LogAnalytics/diagnostics-plan-deploy-policy.json
@@ -5,7 +5,7 @@
     {
       "type": "Microsoft.Authorization/policyDefinitions",
       "name": "diagnostics-plan-deploy-policy",
-      "apiVersion": "2019-09-01",
+      "apiVersion": "2021-06-01",
       "properties": {
         "displayName": "Deploy Diagnostics & Metrics for App Service Plan to a Log Analytics workspace",
         "description": "Apply diagnostic & metric settings for App Service Plan to stream data to a Log Analytics workspace when any App Service Plan which is missing this diagnostic settings is created or updated.",

--- a/ARM/Policy/DiagnosticSettings/LogAnalytics/diagnostics-psql-deploy-policy.json
+++ b/ARM/Policy/DiagnosticSettings/LogAnalytics/diagnostics-psql-deploy-policy.json
@@ -5,7 +5,7 @@
     {
       "type": "Microsoft.Authorization/policyDefinitions",
       "name": "diagnostics-psql-deploy-policy",
-      "apiVersion": "2019-09-01",
+      "apiVersion": "2021-06-01",
       "properties": {
         "displayName": "Deploy Diagnostics & Metrics for PostgreSQL to a Log Analytics workspace",
         "description": "Apply diagnostic & metric settings for PostgreSQL to stream data to a Log Analytics workspace when any PostgreSQL which is missing this diagnostic settings is created or updated.",

--- a/ARM/Policy/DiagnosticSettings/LogAnalytics/diagnostics-redis-deploy-policy.json
+++ b/ARM/Policy/DiagnosticSettings/LogAnalytics/diagnostics-redis-deploy-policy.json
@@ -5,7 +5,7 @@
     {
       "type": "Microsoft.Authorization/policyDefinitions",
       "name": "diagnostics-redis-deploy-policy",
-      "apiVersion": "2019-09-01",
+      "apiVersion": "2021-06-01",
       "properties": {
         "displayName": "Deploy Diagnostics & Metrics for Redis Cache to a Log Analytics workspace",
         "description": "Apply diagnostic & metric settings for Redis Cache to stream data to a Log Analytics workspace when any Redis Cache which is missing this diagnostic settings is created or updated.",

--- a/ARM/Policy/DiagnosticSettings/LogAnalytics/diagnostics-relay-deploy-policy.json
+++ b/ARM/Policy/DiagnosticSettings/LogAnalytics/diagnostics-relay-deploy-policy.json
@@ -5,7 +5,7 @@
     {
       "type": "Microsoft.Authorization/policyDefinitions",
       "name": "diagnostics-relay-deploy-policy",
-      "apiVersion": "2019-09-01",
+      "apiVersion": "2021-06-01",
       "properties": {
         "displayName": "Deploy Diagnostics & Metrics for Relay to a Log Analytics workspace",
         "description": "Apply diagnostic & metric settings for Relay to stream data to a Log Analytics workspace when any Relay which is missing this diagnostic settings is created or updated.",

--- a/ARM/Policy/DiagnosticSettings/LogAnalytics/diagnostics-rsv-deploy-policy.json
+++ b/ARM/Policy/DiagnosticSettings/LogAnalytics/diagnostics-rsv-deploy-policy.json
@@ -5,7 +5,7 @@
     {
       "type": "Microsoft.Authorization/policyDefinitions",
       "name": "diagnostics-rsv-deploy-policy",
-      "apiVersion": "2019-09-01",
+      "apiVersion": "2021-06-01",
       "properties": {
         "displayName": "Deploy Diagnostics & Metrics for Recovery Services Vault to a Log Analytics workspace",
         "description": "Apply diagnostic & metric settings for Recovery Services Vault to stream data to a Log Analytics workspace when any Recovery Services Vault which is missing this diagnostic settings is created or updated.",

--- a/ARM/Policy/DiagnosticSettings/LogAnalytics/diagnostics-sb-deploy-policy.json
+++ b/ARM/Policy/DiagnosticSettings/LogAnalytics/diagnostics-sb-deploy-policy.json
@@ -5,7 +5,7 @@
     {
       "type": "Microsoft.Authorization/policyDefinitions",
       "name": "diagnostics-sb-deploy-policy",
-      "apiVersion": "2019-09-01",
+      "apiVersion": "2021-06-01",
       "properties": {
         "displayName": "Deploy Diagnostics & Metrics for Service Bus to a Log Analytics workspace",
         "description": "Apply diagnostic & metric settings for Service Bus to stream data to a Log Analytics workspace when any Service Bus which is missing this diagnostic settings is created or updated.",

--- a/ARM/Policy/DiagnosticSettings/LogAnalytics/diagnostics-sigr-deploy-policy.json
+++ b/ARM/Policy/DiagnosticSettings/LogAnalytics/diagnostics-sigr-deploy-policy.json
@@ -5,7 +5,7 @@
     {
       "type": "Microsoft.Authorization/policyDefinitions",
       "name": "diagnostics-sigr-deploy-policy",
-      "apiVersion": "2019-09-01",
+      "apiVersion": "2021-06-01",
       "properties": {
         "displayName": "Deploy Diagnostics & Metrics for SignalR to a Log Analytics workspace",
         "description": "Apply diagnostic & metric settings for SignalR to stream data to a Log Analytics workspace when any SignalR which is missing this diagnostic settings is created or updated.",

--- a/ARM/Policy/DiagnosticSettings/LogAnalytics/diagnostics-sqldb-deploy-policy.json
+++ b/ARM/Policy/DiagnosticSettings/LogAnalytics/diagnostics-sqldb-deploy-policy.json
@@ -5,7 +5,7 @@
     {
       "type": "Microsoft.Authorization/policyDefinitions",
       "name": "diagnostics-sqldb-deploy-policy",
-      "apiVersion": "2019-09-01",
+      "apiVersion": "2021-06-01",
       "properties": {
         "displayName": "Deploy Diagnostics & Metrics for SQL Database to a Log Analytics workspace",
         "description": "Apply diagnostic & metric settings for SQL Database to stream data to a Log Analytics workspace when any SQL Database which is missing this diagnostic settings is created or updated.",

--- a/ARM/Policy/DiagnosticSettings/LogAnalytics/diagnostics-sqlel-deploy-policy.json
+++ b/ARM/Policy/DiagnosticSettings/LogAnalytics/diagnostics-sqlel-deploy-policy.json
@@ -5,7 +5,7 @@
     {
       "type": "Microsoft.Authorization/policyDefinitions",
       "name": "diagnostics-sqlel-deploy-policy",
-      "apiVersion": "2019-09-01",
+      "apiVersion": "2021-06-01",
       "properties": {
         "displayName": "Deploy Diagnostics & Metrics for SQL Elastic Pool to a Log Analytics workspace",
         "description": "Apply diagnostic & metric settings for SQL Elastic Pool to stream data to a Log Analytics workspace when any SQL Elastic Pool which is missing this diagnostic settings is created or updated.",

--- a/ARM/Policy/DiagnosticSettings/LogAnalytics/diagnostics-sqlmi-deploy-policy.json
+++ b/ARM/Policy/DiagnosticSettings/LogAnalytics/diagnostics-sqlmi-deploy-policy.json
@@ -5,7 +5,7 @@
     {
       "type": "Microsoft.Authorization/policyDefinitions",
       "name": "diagnostics-sqlmi-deploy-policy",
-      "apiVersion": "2019-09-01",
+      "apiVersion": "2021-06-01",
       "properties": {
         "displayName": "Deploy Diagnostics & Metrics for SQL Managed Instance to a Log Analytics workspace",
         "description": "Apply diagnostic & metric settings for SQL Managed Instance to stream data to a Log Analytics workspace when any SQL Managed Instance which is missing this diagnostic settings is created or updated.",

--- a/ARM/Policy/DiagnosticSettings/LogAnalytics/diagnostics-sqlmidb-deploy-policy.json
+++ b/ARM/Policy/DiagnosticSettings/LogAnalytics/diagnostics-sqlmidb-deploy-policy.json
@@ -5,7 +5,7 @@
     {
       "type": "Microsoft.Authorization/policyDefinitions",
       "name": "diagnostics-sqlmidb-deploy-policy",
-      "apiVersion": "2019-09-01",
+      "apiVersion": "2021-06-01",
       "properties": {
         "displayName": "Deploy Diagnostics & Metrics for SQL Managed Instance Database to a Log Analytics workspace",
         "description": "Apply diagnostic & metric settings for SQL Managed Instance Database to stream data to a Log Analytics workspace when any SQL Managed Instance Database which is missing this diagnostic settings is created or updated.",

--- a/ARM/Policy/DiagnosticSettings/LogAnalytics/diagnostics-srch-deploy-policy.json
+++ b/ARM/Policy/DiagnosticSettings/LogAnalytics/diagnostics-srch-deploy-policy.json
@@ -5,7 +5,7 @@
     {
       "type": "Microsoft.Authorization/policyDefinitions",
       "name": "diagnostics-srch-deploy-policy",
-      "apiVersion": "2019-09-01",
+      "apiVersion": "2021-06-01",
       "properties": {
         "displayName": "Deploy Diagnostics & Metrics for Search to a Log Analytics workspace",
         "description": "Apply diagnostic & metric settings for Search to stream data to a Log Analytics workspace when any Search which is missing this diagnostic settings is created or updated.",

--- a/ARM/Policy/DiagnosticSettings/LogAnalytics/diagnostics-st-blob-deploy-policy.json
+++ b/ARM/Policy/DiagnosticSettings/LogAnalytics/diagnostics-st-blob-deploy-policy.json
@@ -5,7 +5,7 @@
     {
       "type": "Microsoft.Authorization/policyDefinitions",
       "name": "diagnostics-st-blob-deploy-policy",
-      "apiVersion": "2019-09-01",
+      "apiVersion": "2021-06-01",
       "properties": {
         "displayName": "Deploy Diagnostics & Metrics for Storage Account Blob Services to a Log Analytics workspace",
         "description": "Apply diagnostic & metric settings for Storage Account Blob Services to stream data to a Log Analytics workspace when any Storage Account which is missing this diagnostic settings is created or updated.",

--- a/ARM/Policy/DiagnosticSettings/LogAnalytics/diagnostics-st-deploy-policy.json
+++ b/ARM/Policy/DiagnosticSettings/LogAnalytics/diagnostics-st-deploy-policy.json
@@ -5,7 +5,7 @@
     {
       "type": "Microsoft.Authorization/policyDefinitions",
       "name": "diagnostics-st-deploy-policy",
-      "apiVersion": "2019-09-01",
+      "apiVersion": "2021-06-01",
       "properties": {
         "displayName": "Deploy Diagnostics & Metrics for Storage Account to a Log Analytics workspace",
         "description": "Apply diagnostic & metric settings for Storage Account to stream data to a Log Analytics workspace when any Storage Account which is missing this diagnostic settings is created or updated.",

--- a/ARM/Policy/DiagnosticSettings/LogAnalytics/diagnostics-st-file-deploy-policy.json
+++ b/ARM/Policy/DiagnosticSettings/LogAnalytics/diagnostics-st-file-deploy-policy.json
@@ -5,7 +5,7 @@
     {
       "type": "Microsoft.Authorization/policyDefinitions",
       "name": "diagnostics-st-file-deploy-policy",
-      "apiVersion": "2019-09-01",
+      "apiVersion": "2021-06-01",
       "properties": {
         "displayName": "Deploy Diagnostics & Metrics for Storage Account File Services to a Log Analytics workspace",
         "description": "Apply diagnostic & metric settings for Storage Account File Services to stream data to a Log Analytics workspace when any Storage Account which is missing this diagnostic settings is created or updated.",

--- a/ARM/Policy/DiagnosticSettings/LogAnalytics/diagnostics-st-queue-deploy-policy.json
+++ b/ARM/Policy/DiagnosticSettings/LogAnalytics/diagnostics-st-queue-deploy-policy.json
@@ -5,7 +5,7 @@
     {
       "type": "Microsoft.Authorization/policyDefinitions",
       "name": "diagnostics-st-queue-deploy-policy",
-      "apiVersion": "2019-09-01",
+      "apiVersion": "2021-06-01",
       "properties": {
         "displayName": "Deploy Diagnostics & Metrics for Storage Account Queue Services to a Log Analytics workspace",
         "description": "Apply diagnostic & metric settings for Storage Account Queue Services to stream data to a Log Analytics workspace when any Storage Account which is missing this diagnostic settings is created or updated.",

--- a/ARM/Policy/DiagnosticSettings/LogAnalytics/diagnostics-st-table-deploy-policy.json
+++ b/ARM/Policy/DiagnosticSettings/LogAnalytics/diagnostics-st-table-deploy-policy.json
@@ -5,7 +5,7 @@
     {
       "type": "Microsoft.Authorization/policyDefinitions",
       "name": "diagnostics-st-table-deploy-policy",
-      "apiVersion": "2019-09-01",
+      "apiVersion": "2021-06-01",
       "properties": {
         "displayName": "Deploy Diagnostics & Metrics for Storage Account Table Services to a Log Analytics workspace",
         "description": "Apply diagnostic & metric settings for Storage Account Table Services to stream data to a Log Analytics workspace when any Storage Account which is missing this diagnostic settings is created or updated.",

--- a/ARM/Policy/DiagnosticSettings/LogAnalytics/diagnostics-sub-deploy-policy.json
+++ b/ARM/Policy/DiagnosticSettings/LogAnalytics/diagnostics-sub-deploy-policy.json
@@ -5,7 +5,7 @@
     {
       "type": "Microsoft.Authorization/policyDefinitions",
       "name": "diagnostics-sub-deploy-policy",
-      "apiVersion": "2019-09-01",
+      "apiVersion": "2021-06-01",
       "properties": {
         "displayName": "Deploy Diagnostics & Metrics for Subscription to a Log Analytics workspace",
         "description": "Apply diagnostic & metric settings for Subscription to stream data to a Log Analytics workspace when any Subscription which is missing this diagnostic settings is created or updated.",

--- a/ARM/Policy/DiagnosticSettings/LogAnalytics/diagnostics-traf-deploy-policy.json
+++ b/ARM/Policy/DiagnosticSettings/LogAnalytics/diagnostics-traf-deploy-policy.json
@@ -5,7 +5,7 @@
     {
       "type": "Microsoft.Authorization/policyDefinitions",
       "name": "diagnostics-traf-deploy-policy",
-      "apiVersion": "2019-09-01",
+      "apiVersion": "2021-06-01",
       "properties": {
         "displayName": "Deploy Diagnostics & Metrics for Traffic Manager to a Log Analytics workspace",
         "description": "Apply diagnostic & metric settings for Traffic Manager to stream data to a Log Analytics workspace when any Traffic Manager which is missing this diagnostic settings is created or updated.",

--- a/ARM/Policy/DiagnosticSettings/LogAnalytics/diagnostics-tsi-deploy-policy.json
+++ b/ARM/Policy/DiagnosticSettings/LogAnalytics/diagnostics-tsi-deploy-policy.json
@@ -5,7 +5,7 @@
     {
       "type": "Microsoft.Authorization/policyDefinitions",
       "name": "diagnostics-tsi-deploy-policy",
-      "apiVersion": "2019-09-01",
+      "apiVersion": "2021-06-01",
       "properties": {
         "displayName": "Deploy Diagnostics & Metrics for Time Series Insight to a Log Analytics workspace",
         "description": "Apply diagnostic & metric settings for Time Series Insight to stream data to a Log Analytics workspace when any Time Series Insight which is missing this diagnostic settings is created or updated.",

--- a/ARM/Policy/DiagnosticSettings/LogAnalytics/diagnostics-vgw-deploy-policy.json
+++ b/ARM/Policy/DiagnosticSettings/LogAnalytics/diagnostics-vgw-deploy-policy.json
@@ -5,7 +5,7 @@
     {
       "type": "Microsoft.Authorization/policyDefinitions",
       "name": "diagnostics-vgw-deploy-policy",
-      "apiVersion": "2019-09-01",
+      "apiVersion": "2021-06-01",
       "properties": {
         "displayName": "Deploy Diagnostics & Metrics for Virtual Network Gateways to a Log Analytics workspace",
         "description": "Apply diagnostic & metric settings for Virtual Network Gateways to stream data to a Log Analytics workspace when any Virtual Network Gateways which is missing this diagnostic settings is created or updated.",

--- a/ARM/Policy/DiagnosticSettings/LogAnalytics/diagnostics-vm-deploy-policy.json
+++ b/ARM/Policy/DiagnosticSettings/LogAnalytics/diagnostics-vm-deploy-policy.json
@@ -5,7 +5,7 @@
     {
       "type": "Microsoft.Authorization/policyDefinitions",
       "name": "diagnostics-vm-deploy-policy",
-      "apiVersion": "2019-09-01",
+      "apiVersion": "2021-06-01",
       "properties": {
         "displayName": "Deploy Diagnostics & Metrics for Virtual Machines to a Log Analytics workspace",
         "description": "Apply diagnostic & metric settings for Virtual Machines to stream data to a Log Analytics workspace when any Virtual Machines which is missing this diagnostic settings is created or updated.",

--- a/ARM/Policy/DiagnosticSettings/LogAnalytics/diagnostics-vmss-deploy-policy.json
+++ b/ARM/Policy/DiagnosticSettings/LogAnalytics/diagnostics-vmss-deploy-policy.json
@@ -5,7 +5,7 @@
     {
       "type": "Microsoft.Authorization/policyDefinitions",
       "name": "diagnostics-vmss-deploy-policy",
-      "apiVersion": "2019-09-01",
+      "apiVersion": "2021-06-01",
       "properties": {
         "displayName": "Deploy Diagnostics & Metrics for Virtual Machine Scale Sets to a Log Analytics workspace",
         "description": "Apply diagnostic & metric settings for Virtual Machine Scale Sets to stream data to a Log Analytics workspace when any Virtual Machine Scale Sets which is missing this diagnostic settings is created or updated.",

--- a/ARM/Policy/DiagnosticSettings/LogAnalytics/diagnostics-wvdappgroup-deploy-policy.json
+++ b/ARM/Policy/DiagnosticSettings/LogAnalytics/diagnostics-wvdappgroup-deploy-policy.json
@@ -5,7 +5,7 @@
     {
       "type": "Microsoft.Authorization/policyDefinitions",
       "name": "diagnostics-wvdappgroup-deploy-policy",
-      "apiVersion": "2019-09-01",
+      "apiVersion": "2021-06-01",
       "properties": {
         "displayName": "Deploy Diagnostics & Metrics for Windows Virtual Desktop Application Groups to a Log Analytics workspace",
         "description": "Apply diagnostic & metric settings for Windows Virtual Desktop Application Groups to stream data to a Log Analytics workspace when any Windows Virtual Desktop Application Groups which is missing this diagnostic settings is created or updated.",

--- a/ARM/Policy/DiagnosticSettings/LogAnalytics/diagnostics-wvdhostpool-deploy-policy.json
+++ b/ARM/Policy/DiagnosticSettings/LogAnalytics/diagnostics-wvdhostpool-deploy-policy.json
@@ -5,7 +5,7 @@
     {
       "type": "Microsoft.Authorization/policyDefinitions",
       "name": "diagnostics-wvdhostpool-deploy-policy",
-      "apiVersion": "2019-09-01",
+      "apiVersion": "2021-06-01",
       "properties": {
         "displayName": "Deploy Diagnostics & Metrics for Virtual Desktop Host Pools to a Log Analytics workspace",
         "description": "Apply diagnostic & metric settings for Virtual Desktop Host Pools to stream data to a Log Analytics workspace when any Virtual Desktop Host Pools which is missing this diagnostic settings is created or updated.",

--- a/ARM/Policy/DiagnosticSettings/LogAnalytics/diagnostics-wvdworkspace-deploy-policy.json
+++ b/ARM/Policy/DiagnosticSettings/LogAnalytics/diagnostics-wvdworkspace-deploy-policy.json
@@ -6,7 +6,7 @@
     {
       "type": "Microsoft.Authorization/policyDefinitions",
       "name": "diagnostics-wvdworkspace-deploy-policy",
-      "apiVersion": "2019-09-01",
+      "apiVersion": "2021-06-01",
       "properties": {
         "displayName": "Deploy Diagnostics & Metrics for Windows Virtual Desktop Workspaces to a Log Analytics workspace",
         "description": "Apply diagnostic & metric settings for Windows Virtual Desktop Workspaces to stream data to a Log Analytics workspace when any Windows Virtual Desktop Workspaces which is missing this diagnostic settings is created or updated.",


### PR DESCRIPTION
Due to advances in ARMTTK it is now possible to re-enable all the ARM TTK tests, resulting in the requirement to update the API versions of the Policy endpoint for all the diagnostic policies.